### PR TITLE
docs(ci): document deterministic version preparation workflow

### DIFF
--- a/.github/workflows/prepare_version.yaml
+++ b/.github/workflows/prepare_version.yaml
@@ -1,0 +1,847 @@
+name: Prepare version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target Flutter version (X.Y.Z+N)'
+        required: true
+        type: string
+
+      changelog:
+        description: 'Canonical Markdown release notes'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: version-preparation-develop
+  cancel-in-progress: false
+
+jobs:
+  prepare_version:
+    name: Prepare version
+    runs-on: ubuntu-latest
+
+    env:
+      TARGET_BRANCH: develop
+      TARGET_VERSION: ${{ inputs.version }}
+      CHANGELOG_INPUT: ${{ inputs.changelog }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Start timer
+        id: timer
+        shell: bash
+        run: |
+          echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout canonical develop
+        uses: actions/checkout@v5
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Capture develop HEAD
+        id: head
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          HEAD_OID="$(git rev-parse HEAD)"
+
+          echo "oid=${HEAD_OID}" >> "$GITHUB_OUTPUT"
+          echo "Canonical develop HEAD: ${HEAD_OID}"
+
+      - name: Validate and prepare version state
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 <<'PY'
+          import datetime
+          import hashlib
+          import os
+          import pathlib
+          import re
+          import sys
+
+          target_version = os.environ["TARGET_VERSION"].strip()
+          changelog_input = os.environ["CHANGELOG_INPUT"]
+
+          output_file = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+
+          pubspec_path = pathlib.Path("pubspec.yaml")
+          changelog_path = pathlib.Path("CHANGELOG.md")
+
+          version_pattern = re.compile(
+              r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\+(0|[1-9]\d*)$"
+          )
+
+          semver_heading_pattern = re.compile(
+               r"^##\s+\[(\d+\.\d+\.\d+)\]\s+-\s+(\d{4}-\d{2}-\d{2})\s*$",
+               re.MULTILINE,
+          )
+
+          unreleased_pattern = re.compile(
+              r"^## Unreleased\s*$",
+              re.MULTILINE,
+          )
+
+          second_level_heading_pattern = re.compile(
+              r"^##\s+.+$",
+              re.MULTILINE,
+          )
+
+          def emit(key: str, value: object) -> None:
+              with output_file.open("a", encoding="utf-8") as output:
+                  output.write(f"{key}={value}\n")
+
+          def fail(state: str, message: str) -> None:
+              emit("state", state)
+              emit("reason", message.replace("\n", " "))
+              print(f"::error title={state}::{message}")
+              sys.exit(1)
+
+          def canonical_notes(value: str) -> str:
+              value = value.replace("\r\n", "\n").replace("\r", "\n")
+
+              lines = [line.rstrip() for line in value.split("\n")]
+
+              while lines and not lines[0].strip():
+                  lines.pop(0)
+
+              while lines and not lines[-1].strip():
+                  lines.pop()
+
+              return "\n".join(lines)
+
+          def parse_version(value: str, state: str):
+              match = version_pattern.fullmatch(value)
+
+              if match is None:
+                  fail(
+                      state,
+                      f"Version '{value}' must match X.Y.Z+N using non-negative integers.",
+                  )
+
+              major, minor, patch, build = map(int, match.groups())
+
+              return (major, minor, patch), build
+
+          def release_blocks(text: str, semver: str):
+              blocks = []
+
+              headings = list(second_level_heading_pattern.finditer(text))
+
+              for index, heading in enumerate(headings):
+                  line = heading.group(0)
+
+                  match = re.fullmatch(
+                      rf"##\s+\[{re.escape(semver)}\]\s+-\s+(\d{{4}}-\d{{2}}-\d{{2}})\s*",
+                      line,
+                  )
+
+                  if match is None:
+                      continue
+
+                  content_start = heading.end()
+                  content_end = (
+                      headings[index + 1].start()
+                      if index + 1 < len(headings)
+                      else len(text)
+                  )
+
+                  blocks.append(
+                      {
+                          "date": match.group(1),
+                          "notes": canonical_notes(
+                              text[content_start:content_end]
+                          ),
+                      }
+                  )
+
+              return blocks
+
+          if not pubspec_path.is_file():
+              fail(
+                  "VERSION_STATE_INCONSISTENT",
+                  "pubspec.yaml does not exist at repository root.",
+              )
+
+          if not changelog_path.is_file():
+              fail(
+                  "VERSION_STATE_INCONSISTENT",
+                  "CHANGELOG.md does not exist at repository root.",
+              )
+
+          target_match = version_pattern.fullmatch(target_version)
+
+          if target_match is None:
+              fail(
+                  "VERSION_INPUT_INVALID",
+                  f"Target version '{target_version}' must match X.Y.Z+N.",
+              )
+
+          target_semver_tuple, target_build = parse_version(
+              target_version,
+              "VERSION_INPUT_INVALID",
+          )
+
+          target_semver = ".".join(
+              str(value) for value in target_semver_tuple
+          )
+
+          notes = canonical_notes(changelog_input)
+
+          if not notes:
+              fail(
+                  "CHANGELOG_INPUT_INVALID",
+                  "The canonical changelog block cannot be empty.",
+              )
+
+          if re.search(r"^##\s+", notes, re.MULTILINE):
+              fail(
+                  "CHANGELOG_INPUT_INVALID",
+                  "The changelog input must not contain level-2 headings. "
+                  "VERSION owns Unreleased and version headers.",
+              )
+
+          pubspec = pubspec_path.read_text(encoding="utf-8")
+
+          version_lines = list(
+              re.finditer(
+                  r"^version:\s*([^\s#]+)\s*(?:#.*)?$",
+                  pubspec,
+                  re.MULTILINE,
+              )
+          )
+
+          if len(version_lines) != 1:
+              fail(
+                  "VERSION_STATE_INCONSISTENT",
+                  "pubspec.yaml must contain exactly one root version declaration.",
+              )
+
+          current_version = version_lines[0].group(1)
+
+          current_semver_tuple, current_build = parse_version(
+              current_version,
+              "VERSION_STATE_INCONSISTENT",
+          )
+
+          current_semver = ".".join(
+              str(value) for value in current_semver_tuple
+          )
+
+          changelog = changelog_path.read_text(encoding="utf-8")
+
+          unreleased_matches = list(unreleased_pattern.finditer(changelog))
+
+          if len(unreleased_matches) != 1:
+              fail(
+                  "VERSION_STATE_INCONSISTENT",
+                  "CHANGELOG.md must contain exactly one '## Unreleased' heading.",
+              )
+
+          target_blocks = release_blocks(changelog, target_semver)
+
+          notes_sha = hashlib.sha256(
+              notes.encode("utf-8")
+          ).hexdigest()
+
+          emit("previous_version", current_version)
+          emit("previous_semver", current_semver)
+          emit("previous_build", current_build)
+
+          emit("target_version", target_version)
+          emit("target_semver", target_semver)
+          emit("target_build", target_build)
+
+          emit("notes_sha", notes_sha)
+
+          if target_version == current_version:
+              if len(target_blocks) != 1:
+                  fail(
+                      "VERSION_STATE_INCONSISTENT",
+                      "pubspec.yaml already contains the target version but "
+                      "CHANGELOG.md does not contain exactly one matching release block.",
+                  )
+
+              existing = target_blocks[0]
+
+              if existing["notes"] != notes:
+                  fail(
+                      "VERSION_STATE_INCONSISTENT",
+                      "The target version is already prepared but its homologated "
+                      "CHANGELOG content differs from the supplied canonical block.",
+                  )
+
+              emit("release_date", existing["date"])
+              emit("semver_gate", "same")
+              emit("build_gate", "same")
+              emit("state", "VERSION_ALREADY_PREPARED")
+              emit("reason", "Exact target version and changelog are already homologated.")
+
+              print(
+                  f"VERSION_ALREADY_PREPARED: {target_version}"
+              )
+
+              sys.exit(0)
+
+          if target_semver_tuple == current_semver_tuple:
+              fail(
+                  "VERSION_REBUILD_UNSUPPORTED",
+                  "A higher build number for the same SemVer is outside this workflow contract.",
+              )
+
+          if target_semver_tuple < current_semver_tuple:
+              fail(
+                  "VERSION_REGRESSION",
+                  f"Target SemVer {target_semver} is lower than current {current_semver}.",
+              )
+
+          emit("semver_gate", "pass")
+
+          if target_build <= current_build:
+              fail(
+                  "BUILD_REGRESSION",
+                  f"Target build {target_build} must be greater than current build {current_build}.",
+              )
+
+          emit("build_gate", "pass")
+
+          if target_blocks:
+              fail(
+                  "VERSION_STATE_INCONSISTENT",
+                  f"CHANGELOG.md already contains release block {target_semver} "
+                  "while pubspec.yaml is still at another version.",
+              )
+
+          unreleased = unreleased_matches[0]
+
+          following_headings = [
+              heading
+              for heading in second_level_heading_pattern.finditer(
+                  changelog,
+                  unreleased.end(),
+              )
+          ]
+
+          next_heading_start = (
+              following_headings[0].start()
+              if following_headings
+              else len(changelog)
+          )
+
+          staged_unreleased = canonical_notes(
+              changelog[unreleased.end():next_heading_start]
+          )
+
+          material_lines = [
+              line
+              for line in staged_unreleased.splitlines()
+              if line.strip() and not line.lstrip().startswith("#")
+          ]
+
+          if not material_lines:
+              fail(
+                  "UNRELEASED_EMPTY",
+                  "A new version cannot be prepared because ## Unreleased "
+                  "contains no material contribution notes.",
+              )
+
+          release_date = datetime.datetime.now(
+              datetime.timezone.utc
+          ).date().isoformat()
+
+          new_pubspec = (
+              pubspec[:version_lines[0].start()]
+              + f"version: {target_version}"
+              + pubspec[version_lines[0].end():]
+          )
+
+          prefix = changelog[:unreleased.end()].rstrip()
+
+          suffix = changelog[next_heading_start:].lstrip("\n")
+
+          new_changelog = (
+              f"{prefix}\n\n"
+              f"## [{target_semver}] - {release_date}\n\n"
+              f"{notes}\n"
+          )
+
+          if suffix:
+              new_changelog += f"\n{suffix}"
+
+          if not new_changelog.endswith("\n"):
+              new_changelog += "\n"
+
+          pubspec_path.write_text(
+              new_pubspec,
+              encoding="utf-8",
+          )
+
+          changelog_path.write_text(
+              new_changelog,
+              encoding="utf-8",
+          )
+
+          emit("release_date", release_date)
+          emit("state", "NEW_PREPARATION")
+          emit(
+              "reason",
+              "Target version and canonical changelog are ready for atomic materialization.",
+          )
+
+          print(f"Current version: {current_version}")
+          print(f"Target version:  {target_version}")
+          print(f"Release date:    {release_date}")
+          print("State:           NEW_PREPARATION")
+          PY
+
+      - name: Show prepared diff
+        if: steps.prepare.outputs.state == 'NEW_PREPARATION'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git diff --check
+          git diff -- pubspec.yaml CHANGELOG.md
+
+      - name: Create verified version commit
+        id: commit
+        if: steps.prepare.outputs.state == 'NEW_PREPARATION'
+        shell: bash
+        env:
+          EXPECTED_HEAD_OID: ${{ steps.head.outputs.oid }}
+          AUTHORIZED_BY: ${{ github.actor }}
+          TRIGGERED_BY: ${{ github.triggering_actor }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+
+          PUBSPEC_BASE64="$(
+            base64 < pubspec.yaml |
+              tr -d '\n'
+          )"
+
+          CHANGELOG_BASE64="$(
+            base64 < CHANGELOG.md |
+              tr -d '\n'
+          )"
+
+          COMMIT_BODY="$(
+            cat <<EOF
+          Version authorized by @${AUTHORIZED_BY}
+          Workflow triggered by @${TRIGGERED_BY}
+          Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}
+          Attempt: ${RUN_ATTEMPT}
+          EOF
+          )"
+
+          QUERY='
+            mutation CreateVersionCommit(
+              $input: CreateCommitOnBranchInput!
+            ) {
+              createCommitOnBranch(input: $input) {
+                commit {
+                  oid
+                  url
+                }
+              }
+            }
+          '
+
+          PAYLOAD="$(
+            jq -n \
+              --arg query "$QUERY" \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg branch "$TARGET_BRANCH" \
+              --arg head "$EXPECTED_HEAD_OID" \
+              --arg version "$TARGET_VERSION" \
+              --arg body "$COMMIT_BODY" \
+              --arg pubspec "$PUBSPEC_BASE64" \
+              --arg changelog "$CHANGELOG_BASE64" \
+              --arg client_id "version-${RUN_ID}-${RUN_ATTEMPT}" \
+              '{
+                query: $query,
+                variables: {
+                  input: {
+                    branch: {
+                      repositoryNameWithOwner: $repository,
+                      branchName: $branch
+                    },
+                    expectedHeadOid: $head,
+                    message: {
+                      headline: ("chore(release): prepare version " + $version),
+                      body: $body
+                    },
+                    fileChanges: {
+                      additions: [
+                        {
+                          path: "pubspec.yaml",
+                          contents: $pubspec
+                        },
+                        {
+                          path: "CHANGELOG.md",
+                          contents: $changelog
+                        }
+                      ]
+                    },
+                    clientMutationId: $client_id
+                  }
+                }
+              }'
+          )"
+
+          RESPONSE="$(
+            curl -sSf \
+              -X POST \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "Content-Type: application/json" \
+              https://api.github.com/graphql \
+              --data "$PAYLOAD"
+          )"
+
+          if [[ "$(jq '.errors | length // 0' <<< "$RESPONSE")" -gt 0 ]]; then
+            echo "$RESPONSE" | jq '.errors'
+
+            echo "::error title=VERSION_COMMIT_FAILED::GitHub rejected the atomic version commit."
+            exit 1
+          fi
+
+          COMMIT_SHA="$(
+            jq -r '.data.createCommitOnBranch.commit.oid // empty' \
+              <<< "$RESPONSE"
+          )"
+
+          COMMIT_URL="$(
+            jq -r '.data.createCommitOnBranch.commit.url // empty' \
+              <<< "$RESPONSE"
+          )"
+
+          if [[ -z "$COMMIT_SHA" ]]; then
+            echo "::error title=VERSION_COMMIT_FAILED::GitHub returned no commit SHA."
+            exit 1
+          fi
+
+          echo "sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "url=${COMMIT_URL}" >> "$GITHUB_OUTPUT"
+
+          echo "Created version commit: ${COMMIT_SHA}"
+
+      - name: Verify materialized version
+        id: verify
+        if: steps.prepare.outputs.state == 'NEW_PREPARATION'
+        shell: bash
+        env:
+          COMMIT_SHA: ${{ steps.commit.outputs.sha }}
+          EXPECTED_VERSION: ${{ steps.prepare.outputs.target_version }}
+          EXPECTED_SEMVER: ${{ steps.prepare.outputs.target_semver }}
+          EXPECTED_NOTES_SHA: ${{ steps.prepare.outputs.notes_sha }}
+        run: |
+          set -euo pipefail
+
+          RESPONSE="$(
+            curl -sSf \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${COMMIT_SHA}"
+          )"
+
+          VERIFIED="$(
+            jq -r '.commit.verification.verified' <<< "$RESPONSE"
+          )"
+
+          VERIFY_REASON="$(
+            jq -r '.commit.verification.reason' <<< "$RESPONSE"
+          )"
+
+          echo "verified=${VERIFIED}" >> "$GITHUB_OUTPUT"
+          echo "reason=${VERIFY_REASON}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$VERIFIED" != "true" ]]; then
+            echo "::error title=VERSION_COMMIT_UNVERIFIED::Commit ${COMMIT_SHA} is not GitHub Verified (${VERIFY_REASON})."
+            exit 1
+          fi
+
+          git fetch origin develop
+
+          if ! git cat-file -e "${COMMIT_SHA}^{commit}" 2>/dev/null; then
+            echo "::error title=VERSION_POSTCONDITION_FAILED::Materialized commit is not reachable."
+            exit 1
+          fi
+
+          git show "${COMMIT_SHA}:pubspec.yaml" \
+            > "${RUNNER_TEMP}/prepared_pubspec.yaml"
+
+          git show "${COMMIT_SHA}:CHANGELOG.md" \
+            > "${RUNNER_TEMP}/prepared_changelog.md"
+
+          python3 <<'PY'
+          import hashlib
+          import os
+          import pathlib
+          import re
+          import sys
+
+          version = os.environ["EXPECTED_VERSION"]
+          semver = os.environ["EXPECTED_SEMVER"]
+          expected_notes_sha = os.environ["EXPECTED_NOTES_SHA"]
+
+          pubspec = pathlib.Path(
+              os.environ["RUNNER_TEMP"],
+              "prepared_pubspec.yaml",
+          ).read_text(encoding="utf-8")
+
+          changelog = pathlib.Path(
+              os.environ["RUNNER_TEMP"],
+              "prepared_changelog.md",
+          ).read_text(encoding="utf-8")
+
+          versions = re.findall(
+              r"^version:\s*([^\s#]+)",
+              pubspec,
+              re.MULTILINE,
+          )
+
+          if versions != [version]:
+              print(
+                  "::error title=VERSION_POSTCONDITION_FAILED::"
+                  "Materialized pubspec.yaml does not contain the exact target version."
+              )
+              sys.exit(1)
+
+          heading_pattern = re.compile(
+              rf"^##\s+\[{re.escape(semver)}\]\s+-\s+\d{{4}}-\d{{2}}-\d{{2}}\s*$",
+              re.MULTILINE,
+          )
+
+          headings = list(heading_pattern.finditer(changelog))
+
+          if len(headings) != 1:
+              print(
+                  "::error title=VERSION_POSTCONDITION_FAILED::"
+                  "Materialized CHANGELOG does not contain exactly one target version block."
+              )
+              sys.exit(1)
+
+          all_second_level = list(
+              re.finditer(
+                  r"^##\s+.+$",
+                  changelog,
+                  re.MULTILINE,
+              )
+          )
+
+          target_heading = headings[0]
+          target_index = next(
+              index
+              for index, item in enumerate(all_second_level)
+              if item.start() == target_heading.start()
+          )
+
+          content_end = (
+              all_second_level[target_index + 1].start()
+              if target_index + 1 < len(all_second_level)
+              else len(changelog)
+          )
+
+          notes = changelog[
+              target_heading.end():content_end
+          ].replace("\r\n", "\n").replace("\r", "\n")
+
+          lines = [line.rstrip() for line in notes.splitlines()]
+
+          while lines and not lines[0].strip():
+              lines.pop(0)
+
+          while lines and not lines[-1].strip():
+              lines.pop()
+
+          canonical = "\n".join(lines)
+
+          actual_sha = hashlib.sha256(
+              canonical.encode("utf-8")
+          ).hexdigest()
+
+          if actual_sha != expected_notes_sha:
+              print(
+                  "::error title=VERSION_POSTCONDITION_FAILED::"
+                  "Materialized CHANGELOG differs from the canonical release notes."
+              )
+              sys.exit(1)
+
+          if len(
+              re.findall(
+                  r"^## Unreleased\s*$",
+                  changelog,
+                  re.MULTILINE,
+              )
+          ) != 1:
+              print(
+                  "::error title=VERSION_POSTCONDITION_FAILED::"
+                  "CHANGELOG must retain exactly one Unreleased block."
+              )
+              sys.exit(1)
+
+          print("Version postconditions verified.")
+          PY
+
+      - name: Write version preparation summary
+        if: always()
+        shell: bash
+        env:
+          STARTED_AT: ${{ steps.timer.outputs.started_at }}
+
+          STATE: ${{ steps.prepare.outputs.state }}
+          REASON: ${{ steps.prepare.outputs.reason }}
+
+          PREVIOUS_VERSION: ${{ steps.prepare.outputs.previous_version }}
+          PREVIOUS_SEMVER: ${{ steps.prepare.outputs.previous_semver }}
+          PREVIOUS_BUILD: ${{ steps.prepare.outputs.previous_build }}
+
+          TARGET_VERSION_OUTPUT: ${{ steps.prepare.outputs.target_version }}
+          TARGET_SEMVER: ${{ steps.prepare.outputs.target_semver }}
+          TARGET_BUILD: ${{ steps.prepare.outputs.target_build }}
+
+          SEMVER_GATE: ${{ steps.prepare.outputs.semver_gate }}
+          BUILD_GATE: ${{ steps.prepare.outputs.build_gate }}
+          RELEASE_DATE: ${{ steps.prepare.outputs.release_date }}
+
+          COMMIT_SHA: ${{ steps.commit.outputs.sha }}
+          COMMIT_URL: ${{ steps.commit.outputs.url }}
+
+          COMMIT_VERIFIED: ${{ steps.verify.outputs.verified }}
+
+          AUTHORIZED_BY: ${{ github.actor }}
+          TRIGGERED_BY: ${{ github.triggering_actor }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+
+          value_or_na() {
+            if [[ -z "${1:-}" ]]; then
+              printf 'N/A'
+            else
+              printf '%s' "$1"
+            fi
+          }
+
+          gate() {
+            case "${1:-}" in
+              pass)
+                printf '✅ PASS'
+                ;;
+              same)
+                printf '✅ ALREADY HOMOLOGATED'
+                ;;
+              *)
+                printf 'N/A'
+                ;;
+            esac
+          }
+
+          state_result() {
+            case "${1:-}" in
+              NEW_PREPARATION)
+                printf '✅ VERSION_PREPARED'
+                ;;
+              VERSION_ALREADY_PREPARED)
+                printf '✅ VERSION_ALREADY_PREPARED'
+                ;;
+              *)
+                printf '❌ %s' "$(value_or_na "${1:-}")"
+                ;;
+            esac
+          }
+
+          finished_at="$(date +%s)"
+          duration="N/A"
+
+          if [[ "${STARTED_AT:-}" =~ ^[0-9]+$ ]]; then
+            duration="$((finished_at - STARTED_AT))s"
+          fi
+
+          mutation="none"
+
+          if [[ -n "${COMMIT_SHA:-}" ]]; then
+            mutation="atomic commit"
+          fi
+
+          signature="N/A"
+
+          if [[ "${COMMIT_VERIFIED:-}" == "true" ]]; then
+            signature="✅ GitHub Verified"
+          elif [[ -n "${COMMIT_SHA:-}" ]]; then
+            signature="❌ NOT VERIFIED"
+          fi
+
+          {
+            echo "## Version Preparation"
+            echo ""
+            echo "**Status:** $(state_result "${STATE:-}")"
+            echo ""
+
+            echo "### Authorization"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Requested by | @${AUTHORIZED_BY} |"
+            echo "| Triggered by | @${TRIGGERED_BY} |"
+            echo "| Workflow attempt | ${RUN_ATTEMPT} |"
+            echo "| Target branch | \`${TARGET_BRANCH}\` |"
+            echo ""
+
+            echo "### Version"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Previous | $(value_or_na "${PREVIOUS_VERSION:-}") |"
+            echo "| Target | $(value_or_na "${TARGET_VERSION_OUTPUT:-}") |"
+            echo "| SemVer | $(value_or_na "${TARGET_SEMVER:-}") |"
+            echo "| SemVer monotonic | $(gate "${SEMVER_GATE:-}") |"
+            echo "| Previous build | $(value_or_na "${PREVIOUS_BUILD:-}") |"
+            echo "| Target build | $(value_or_na "${TARGET_BUILD:-}") |"
+            echo "| Build monotonic | $(gate "${BUILD_GATE:-}") |"
+            echo ""
+
+            echo "### CHANGELOG"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Canonical notes | ✅ supplied |"
+            echo "| Version block | $(value_or_na "${TARGET_SEMVER:-}") |"
+            echo "| Release date | $(value_or_na "${RELEASE_DATE:-}") |"
+            echo ""
+
+            echo "### Materialization"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Idempotency state | $(value_or_na "${STATE:-}") |"
+            echo "| Mutation | ${mutation} |"
+            echo "| Commit | $(value_or_na "${COMMIT_SHA:-}") |"
+            echo "| Signature | ${signature} |"
+            echo "| Duration | ${duration} |"
+            echo ""
+
+            if [[ -n "${COMMIT_URL:-}" ]]; then
+              echo "[Open version commit](${COMMIT_URL})"
+              echo ""
+            fi
+
+            echo "[Open workflow run](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID})"
+
+            if [[ -n "${REASON:-}" ]]; then
+              echo ""
+              echo "> ${REASON}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,52 +12,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Fixed] for any bug fixes.
 - [Security] in case of vulnerabilities.
 
-# Changelog
+## Unreleased
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-- [Added] for new features.
-- [Changed] for changes in existing functionality.
-- [Deprecated] for soon-to-be removed features.
-- [Removed] for now removed features.
-- [Fixed] for any bug fixes.
-- [Security] in case of vulnerabilities.
-
-## [1.11.1] - 2026-08-19
-
-Added
+### Added
 
 - Added controlled virtual amount input for income and expense forms.
-- Added "VirtualKeyWidget" as an accessible primitive for virtual keyboard actions.
-- Added "VirtualAmountKeyboardWidget" for digit-only monetary input.
-- Added "AmountMagnifierWidget" with live formatted amount preview.
-- Added explicit amount-editing intents and state management in "BlocIncomeForm".
+- Added `VirtualKeyWidget` as an accessible primitive for virtual keyboard actions.
+- Added `VirtualAmountKeyboardWidget` for digit-only monetary input.
+- Added `AmountMagnifierWidget` with live formatted amount preview.
+- Added explicit amount-editing intents and state management in `BlocIncomeForm`.
 - Added widget and integration coverage for the complete controlled amount-entry flow.
-- Added explicit runtime environment selection through "--dart-define=OKANE_ENV=<dev|qa|prod>".
+- Added explicit runtime environment selection through `--dart-define=OKANE_ENV=<dev|qa|prod>`.
+- Added reusable read-only Flutter validation for push and pull-request workflows.
+- Added configurable pull-request line coverage gate through `COVERAGE_MIN`.
+- Added concise GitHub Actions summaries for base validation, tests and coverage.
+- Added deterministic manual version preparation through `prepare_version.yaml`.
 
-Changed
+### Changed
 
 - Updated project dependencies to their latest compatible versions.
 - Updated Android Gradle, Android Gradle Plugin and Kotlin tooling for compatibility with the current Flutter SDK.
-- Migrated Okane to use the transversal "ProjectorWidget" provided by "jocaaguraarchetype".
-- Changed the local environment implementation to "OkaneEnv extends Env".
+- Migrated Okane to use the transversal `ProjectorWidget` provided by `jocaaguraarchetype`.
+- Changed the local environment implementation to `OkaneEnv extends Env`.
 - Amount entry now stores only canonical numeric digits while Okane controls monetary presentation.
 - Monetary preview preserves the current Colombian accounting representation with two decimal places.
-- "FormLedgerWidget" now resolves "AppManager" from the application context instead of the global composition root.
+- `FormLedgerWidget` now resolves `AppManager` from the application context instead of the global composition root.
+- Unified pull-request validation for `develop` and `master` using the same reusable base validation authority.
+- Separated repository verification from version preparation, artifact generation and publication responsibilities.
+- Defined `develop` as the only canonical branch writable by the VERSION workflow.
 
-Fixed
+### Fixed
 
-- Removed "Env" and "ProjectorWidget" symbol collisions introduced by the Archetype dependency upgrade.
+- Removed `Env` and `ProjectorWidget` symbol collisions introduced by the Archetype dependency upgrade.
 - Prevented the native keyboard from interfering with controlled monetary input.
 - Preserved amount values when closing and reopening the virtual amount editor.
+- Removed duplicated CI validation logic and non-authoritative checks from the previous workflows.
 
-Quality
+### Quality
 
 - Expanded the automated suite to 97 passing tests.
 - Added coverage for amount sanitization, formatting, virtual-key interactions, accessibility semantics and income/expense integration.
+- Established a repository coverage gate with a current baseline of 40%.
+- Certified both PASS and FAIL paths of the coverage gate.
+- Added deterministic version monotonicity, CHANGELOG homologation and rerun-idempotency contracts.
+
 ## [1.11.0] - 2025-09-28
 
 ### Added

--- a/docs/ci/version-preparation.md
+++ b/docs/ci/version-preparation.md
@@ -1,0 +1,653 @@
+# Version Preparation
+
+`prepare_version.yaml` is the canonical VERSION preparation workflow for Okane.
+
+Its responsibility is limited to preparing a deterministic and homologated
+project version on the `develop` branch.
+
+It does **not** build, sign, tag, publish, or deploy artifacts.
+
+---
+
+## Pipeline position
+
+The Jocaagura development pipeline separates responsibilities into four
+boundaries:
+
+```text
+VERIFY
+   ↓
+VERSION
+   ↓
+BUILD
+   ↓
+PUBLISH
+```
+
+### VERIFY
+
+Certifies repository quality:
+
+* verified commits;
+* no `dependency_overrides`;
+* Dart format;
+* strict analyzer;
+* tests;
+* coverage gate.
+
+### VERSION
+
+Prepares the canonical project version:
+
+* SemVer;
+* build number;
+* CHANGELOG;
+* monotonicity;
+* idempotency.
+
+### BUILD
+
+Produces platform-specific artifacts.
+
+Examples:
+
+* Android AAB/APK;
+* iOS IPA/archive;
+* Web build;
+* package artifacts.
+
+### PUBLISH
+
+Publishes an already built artifact to a destination.
+
+Examples:
+
+* Google Play;
+* App Store;
+* pub.dev;
+* hosting/deployment targets.
+
+`prepare_version.yaml` belongs exclusively to **VERSION**.
+
+---
+
+# Authority
+
+The only branch that VERSION is allowed to mutate is:
+
+```text
+develop
+```
+
+The destination branch is fixed by the workflow contract and cannot be
+provided as user input.
+
+`master` must never be versioned by this workflow.
+
+A version reaches `master` only through the normal repository promotion
+process after it has already been prepared and homologated in `develop`.
+
+---
+
+# Human authorization
+
+Version preparation is manually authorized through:
+
+```yaml
+workflow_dispatch
+```
+
+The person executing the workflow explicitly supplies:
+
+```text
+version
+changelog
+```
+
+Example:
+
+```text
+version:
+1.12.0+6
+```
+
+```markdown
+### Added
+
+- Added controlled virtual amount input.
+
+### Changed
+
+- Added deterministic CI version preparation.
+```
+
+The workflow does not infer whether a contribution is:
+
+* patch;
+* minor;
+* major.
+
+That decision belongs to the human release authority.
+
+The workflow validates and materializes the declared intent.
+
+---
+
+# Version format
+
+Okane uses the Flutter version contract:
+
+```yaml
+version: X.Y.Z+N
+```
+
+Example:
+
+```yaml
+version: 1.12.0+6
+```
+
+Where:
+
+```text
+1.12.0 → SemVer
+6      → build number
+```
+
+Both values are part of the VERSION contract.
+
+The target version must have:
+
+```text
+target SemVer > current SemVer
+```
+
+and:
+
+```text
+target build number > current build number
+```
+
+A lower version or build number is rejected.
+
+---
+
+# CHANGELOG contract
+
+Development contributions accumulate under:
+
+```markdown
+## Unreleased
+```
+
+Example:
+
+```markdown
+## Unreleased
+
+### Added
+
+- Added controlled amount entry.
+
+### Changed
+
+- Refactored CI validation.
+```
+
+When VERSION is prepared, the workflow receives the canonical release notes
+explicitly.
+
+The human operator owns the release-note content.
+
+VERSION owns:
+
+* the version heading;
+* the release date;
+* the placement of the block;
+* preservation of `## Unreleased`;
+* prevention of duplicate release blocks.
+
+The supplied changelog input must therefore contain only the release content.
+
+Do not include:
+
+```markdown
+## Unreleased
+```
+
+or:
+
+```markdown
+## [1.12.0] - 2026-08-29
+```
+
+inside the workflow input.
+
+The workflow generates the canonical release heading.
+
+Example result:
+
+```markdown
+## Unreleased
+
+## [1.12.0] - 2026-08-29
+
+### Added
+
+- Added controlled virtual amount input.
+
+### Changed
+
+- Added deterministic CI version preparation.
+```
+
+---
+
+# Preconditions
+
+Before preparing a version:
+
+1. The contribution must already be present in `develop`.
+2. Repository VERIFY checks must be healthy.
+3. `pubspec.yaml` must contain a valid Flutter version:
+
+   ```text
+   X.Y.Z+N
+   ```
+4. `CHANGELOG.md` must contain exactly one:
+
+   ```markdown
+   ## Unreleased
+   ```
+5. `Unreleased` must contain material contribution notes.
+6. The target SemVer must be greater than the current SemVer.
+7. The target build number must be greater than the current build number.
+8. The build number must respect any previously homologated publication
+   number for the target platform.
+
+---
+
+# Running the workflow
+
+## GitHub UI
+
+Open:
+
+```text
+GitHub
+→ Actions
+→ Prepare version
+→ Run workflow
+```
+
+Provide:
+
+```text
+version
+```
+
+using:
+
+```text
+X.Y.Z+N
+```
+
+and provide the canonical Markdown release block in:
+
+```text
+changelog
+```
+
+---
+
+## GitHub CLI
+
+For multiline release notes, using a file is recommended.
+
+Example `release-notes.md`:
+
+```markdown
+### Added
+
+- Added controlled virtual amount input.
+- Added deterministic version preparation.
+
+### Changed
+
+- Unified reusable validation workflows.
+```
+
+Run:
+
+```bash
+gh workflow run prepare_version.yaml \
+  --ref develop \
+  -f version='1.12.0+6' \
+  -F changelog=@release-notes.md
+```
+
+The workflow always mutates `develop`, regardless of the caller context.
+
+---
+
+# Version states
+
+VERSION is fail-closed.
+
+The workflow classifies the repository before performing mutations.
+
+## NEW_PREPARATION
+
+A valid new version can be prepared.
+
+Example:
+
+```text
+current: 1.11.1+5
+target:  1.12.0+6
+```
+
+Expected result:
+
+```text
+VERSION_PREPARED
+```
+
+---
+
+## VERSION_ALREADY_PREPARED
+
+The exact version and canonical changelog block already exist.
+
+Example:
+
+```text
+current: 1.12.0+6
+target:  1.12.0+6
+```
+
+with the same homologated release notes.
+
+Expected result:
+
+```text
+VERSION_ALREADY_PREPARED
+```
+
+This is a successful no-op.
+
+No commit is created.
+
+---
+
+## VERSION_REGRESSION
+
+The target SemVer is lower than the current version.
+
+Expected result:
+
+```text
+FAIL
+```
+
+---
+
+## BUILD_REGRESSION
+
+The new release does not increase the build number.
+
+Expected result:
+
+```text
+FAIL
+```
+
+---
+
+## VERSION_REBUILD_UNSUPPORTED
+
+The target keeps the same SemVer while changing only the build number.
+
+Example:
+
+```text
+1.12.0+6
+→
+1.12.0+7
+```
+
+This workflow does not support this scenario in its current contract.
+
+Expected result:
+
+```text
+FAIL
+```
+
+---
+
+## VERSION_STATE_INCONSISTENT
+
+The repository contains a contradictory or partially prepared state.
+
+Examples:
+
+* `pubspec.yaml` already points to the target version but CHANGELOG does not;
+* CHANGELOG already contains the target release while `pubspec.yaml` is older;
+* the target version exists more than once;
+* the same version exists with different canonical release notes.
+
+Expected result:
+
+```text
+FAIL
+```
+
+VERSION does not automatically repair inconsistent repository states.
+
+---
+
+# Atomic materialization
+
+A successful new preparation modifies exactly:
+
+```text
+pubspec.yaml
+CHANGELOG.md
+```
+
+Both files are written through a single GitHub commit using
+`createCommitOnBranch`.
+
+The workflow uses the current `develop` HEAD as:
+
+```text
+expectedHeadOid
+```
+
+If `develop` changes between validation and commit creation, the operation
+must fail instead of overwriting concurrent work.
+
+This provides optimistic concurrency protection.
+
+---
+
+# Commit verification
+
+The version commit is materialized by GitHub Actions.
+
+The human operator authorizes:
+
+```text
+version + changelog
+```
+
+GitHub Actions performs the repository mutation.
+
+The resulting commit must be:
+
+```text
+GitHub Verified
+```
+
+The workflow verifies this as a postcondition.
+
+The summary must distinguish:
+
+```text
+Human authority
+→ who authorized the VERSION intent
+
+Automated authority
+→ workflow that validated it
+
+Materialization authority
+→ GitHub-signed commit
+```
+
+---
+
+# Summary
+
+Every execution writes a concise GitHub Actions summary.
+
+Example:
+
+```text
+Version Preparation
+
+Status              ✅ VERSION_PREPARED
+Target branch       develop
+
+Authorization
+Requested by         @user
+Triggered by         @user
+Workflow attempt     1
+
+Version
+Previous             1.11.1+5
+Target               1.12.0+6
+SemVer monotonic     ✅
+Build monotonic      ✅
+
+CHANGELOG
+Canonical notes      ✅
+Version block        1.12.0
+Release date         2026-08-29
+
+Materialization
+Mutation             atomic commit
+Commit               <sha>
+Signature            ✅ GitHub Verified
+
+Idempotency
+State                NEW_PREPARATION
+```
+
+For an exact rerun:
+
+```text
+Status               ✅ VERSION_ALREADY_PREPARED
+Mutation             none
+```
+
+---
+
+# Idempotency
+
+Running the same VERSION preparation more than once must never result in
+additional mutations.
+
+An exact rerun must not:
+
+* increment the build number;
+* create another CHANGELOG block;
+* create another commit;
+* modify release notes;
+* change the release date.
+
+The expected result is:
+
+```text
+VERSION_ALREADY_PREPARED
+```
+
+---
+
+# Development workflow
+
+The expected team workflow is:
+
+```text
+feature / contribution branch
+          │
+          ▼
+        VERIFY
+          │
+          ▼
+      PR → develop
+          │
+          ▼
+        develop
+          │
+          ▼
+    prepare_version
+          │
+          ▼
+  VERSION_PREPARED
+```
+
+When a version is ready for promotion:
+
+```text
+develop
+   │
+   ▼
+PR → master
+   │
+   ▼
+master
+```
+
+`master` receives an already homologated version.
+
+Future BUILD and PUBLISH workflows will operate from that boundary.
+
+---
+
+# Responsibilities intentionally excluded
+
+VERSION does not:
+
+* infer patch/minor/major;
+* execute product tests or coverage gates;
+* create Git tags;
+* create GitHub Releases;
+* build APK;
+* build AAB;
+* build IPA;
+* build Web artifacts;
+* sign application artifacts;
+* publish to Google Play;
+* publish to App Store;
+* deploy Web applications;
+* publish packages.
+
+These responsibilities belong to other pipeline boundaries.
+
+---
+
+# Operational rule
+
+If VERSION cannot prove that the repository state is coherent, monotonic,
+idempotent and authorized:
+
+```text
+do not mutate develop
+```
+
+Failing safely is preferable to automatically repairing or guessing the
+intended version state.
+
+```
+```


### PR DESCRIPTION
## Objective

Introduce deterministic VERSION preparation for Okane while keeping artifact generation and publication outside this contribution.

The new workflow establishes `develop` as the canonical version-preparation branch and receives the complete target Flutter version plus canonical release notes as explicit human intent.

## Changes

### Deterministic version preparation

Added `.github/workflows/prepare_version.yaml` with manual `workflow_dispatch` execution.

The workflow receives:

```text
version   = X.Y.Z+N
changelog = canonical Markdown release notes