### PR TITLE
fix(ci): preserve multiline changelog input

### DIFF
--- a/.github/workflows/prepare_version.yaml
+++ b/.github/workflows/prepare_version.yaml
@@ -8,8 +8,8 @@ on:
         required: true
         type: string
 
-      changelog:
-        description: 'Canonical Markdown release notes'
+      changelog_base64:
+        description: 'Canonical UTF-8 Markdown release notes encoded as Base64'
         required: true
         type: string
 
@@ -28,7 +28,7 @@ jobs:
     env:
       TARGET_BRANCH: develop
       TARGET_VERSION: ${{ inputs.version }}
-      CHANGELOG_INPUT: ${{ inputs.changelog }}
+      CHANGELOG_INPUT_BASE64: ${{ inputs.changelog_base64 }}
       GH_TOKEN: ${{ github.token }}
 
     steps:
@@ -62,6 +62,8 @@ jobs:
           set -euo pipefail
 
           python3 <<'PY'
+          import base64
+          import binascii
           import datetime
           import hashlib
           import os
@@ -70,7 +72,7 @@ jobs:
           import sys
 
           target_version = os.environ["TARGET_VERSION"].strip()
-          changelog_input = os.environ["CHANGELOG_INPUT"]
+          changelog_base64 = os.environ["CHANGELOG_INPUT_BASE64"].strip()
 
           output_file = pathlib.Path(os.environ["GITHUB_OUTPUT"])
 
@@ -79,11 +81,6 @@ jobs:
 
           version_pattern = re.compile(
               r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\+(0|[1-9]\d*)$"
-          )
-
-          semver_heading_pattern = re.compile(
-               r"^##\s+\[(\d+\.\d+\.\d+)\]\s+-\s+(\d{4}-\d{2}-\d{2})\s*$",
-               re.MULTILINE,
           )
 
           unreleased_pattern = re.compile(
@@ -135,7 +132,9 @@ jobs:
           def release_blocks(text: str, semver: str):
               blocks = []
 
-              headings = list(second_level_heading_pattern.finditer(text))
+              headings = list(
+                  second_level_heading_pattern.finditer(text)
+              )
 
               for index, heading in enumerate(headings):
                   line = heading.group(0)
@@ -195,12 +194,39 @@ jobs:
               str(value) for value in target_semver_tuple
           )
 
+          if not changelog_base64:
+              fail(
+                  "CHANGELOG_INPUT_INVALID",
+                  "The canonical changelog Base64 input cannot be empty.",
+              )
+
+          try:
+              changelog_input = base64.b64decode(
+                  changelog_base64,
+                  validate=True,
+              ).decode("utf-8")
+          except (binascii.Error, UnicodeDecodeError):
+              fail(
+                  "CHANGELOG_INPUT_INVALID",
+                  "Canonical changelog must be valid Base64 containing UTF-8 Markdown.",
+              )
+
           notes = canonical_notes(changelog_input)
 
           if not notes:
               fail(
                   "CHANGELOG_INPUT_INVALID",
                   "The canonical changelog block cannot be empty.",
+              )
+
+          if not re.search(
+              r"^###\s+\S+",
+              notes,
+              re.MULTILINE,
+          ):
+              fail(
+                  "CHANGELOG_INPUT_INVALID",
+                  "Canonical changelog must contain at least one level-3 release section.",
               )
 
           if re.search(r"^##\s+", notes, re.MULTILINE):
@@ -239,7 +265,9 @@ jobs:
 
           changelog = changelog_path.read_text(encoding="utf-8")
 
-          unreleased_matches = list(unreleased_pattern.finditer(changelog))
+          unreleased_matches = list(
+              unreleased_pattern.finditer(changelog)
+          )
 
           if len(unreleased_matches) != 1:
               fail(
@@ -247,7 +275,10 @@ jobs:
                   "CHANGELOG.md must contain exactly one '## Unreleased' heading.",
               )
 
-          target_blocks = release_blocks(changelog, target_semver)
+          target_blocks = release_blocks(
+              changelog,
+              target_semver,
+          )
 
           notes_sha = hashlib.sha256(
               notes.encode("utf-8")
@@ -284,7 +315,10 @@ jobs:
               emit("semver_gate", "same")
               emit("build_gate", "same")
               emit("state", "VERSION_ALREADY_PREPARED")
-              emit("reason", "Exact target version and changelog are already homologated.")
+              emit(
+                  "reason",
+                  "Exact target version and changelog are already homologated.",
+              )
 
               print(
                   f"VERSION_ALREADY_PREPARED: {target_version}"
@@ -338,13 +372,16 @@ jobs:
           )
 
           staged_unreleased = canonical_notes(
-              changelog[unreleased.end():next_heading_start]
+              changelog[
+                  unreleased.end():next_heading_start
+              ]
           )
 
           material_lines = [
               line
               for line in staged_unreleased.splitlines()
-              if line.strip() and not line.lstrip().startswith("#")
+              if line.strip()
+              and not line.lstrip().startswith("#")
           ]
 
           if not material_lines:
@@ -366,7 +403,9 @@ jobs:
 
           prefix = changelog[:unreleased.end()].rstrip()
 
-          suffix = changelog[next_heading_start:].lstrip("\n")
+          suffix = changelog[
+              next_heading_start:
+          ].lstrip("\n")
 
           new_changelog = (
               f"{prefix}\n\n"
@@ -422,6 +461,7 @@ jobs:
           TRIGGERED_BY: ${{ github.triggering_actor }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+
         run: |
           set -euo pipefail
 
@@ -517,12 +557,14 @@ jobs:
           fi
 
           COMMIT_SHA="$(
-            jq -r '.data.createCommitOnBranch.commit.oid // empty' \
+            jq -r \
+              '.data.createCommitOnBranch.commit.oid // empty' \
               <<< "$RESPONSE"
           )"
 
           COMMIT_URL="$(
-            jq -r '.data.createCommitOnBranch.commit.url // empty' \
+            jq -r \
+              '.data.createCommitOnBranch.commit.url // empty' \
               <<< "$RESPONSE"
           )"
 
@@ -545,6 +587,7 @@ jobs:
           EXPECTED_VERSION: ${{ steps.prepare.outputs.target_version }}
           EXPECTED_SEMVER: ${{ steps.prepare.outputs.target_semver }}
           EXPECTED_NOTES_SHA: ${{ steps.prepare.outputs.notes_sha }}
+
         run: |
           set -euo pipefail
 
@@ -556,11 +599,15 @@ jobs:
           )"
 
           VERIFIED="$(
-            jq -r '.commit.verification.verified' <<< "$RESPONSE"
+            jq -r \
+              '.commit.verification.verified' \
+              <<< "$RESPONSE"
           )"
 
           VERIFY_REASON="$(
-            jq -r '.commit.verification.reason' <<< "$RESPONSE"
+            jq -r \
+              '.commit.verification.reason' \
+              <<< "$RESPONSE"
           )"
 
           echo "verified=${VERIFIED}" >> "$GITHUB_OUTPUT"
@@ -593,7 +640,9 @@ jobs:
 
           version = os.environ["EXPECTED_VERSION"]
           semver = os.environ["EXPECTED_SEMVER"]
-          expected_notes_sha = os.environ["EXPECTED_NOTES_SHA"]
+          expected_notes_sha = os.environ[
+              "EXPECTED_NOTES_SHA"
+          ]
 
           pubspec = pathlib.Path(
               os.environ["RUNNER_TEMP"],
@@ -623,7 +672,9 @@ jobs:
               re.MULTILINE,
           )
 
-          headings = list(heading_pattern.finditer(changelog))
+          headings = list(
+              heading_pattern.finditer(changelog)
+          )
 
           if len(headings) != 1:
               print(
@@ -641,23 +692,38 @@ jobs:
           )
 
           target_heading = headings[0]
+
           target_index = next(
               index
-              for index, item in enumerate(all_second_level)
+              for index, item in enumerate(
+                  all_second_level
+              )
               if item.start() == target_heading.start()
           )
 
           content_end = (
-              all_second_level[target_index + 1].start()
-              if target_index + 1 < len(all_second_level)
+              all_second_level[
+                  target_index + 1
+              ].start()
+              if target_index + 1
+              < len(all_second_level)
               else len(changelog)
           )
 
           notes = changelog[
               target_heading.end():content_end
-          ].replace("\r\n", "\n").replace("\r", "\n")
+          ].replace(
+              "\r\n",
+              "\n",
+          ).replace(
+              "\r",
+              "\n",
+          )
 
-          lines = [line.rstrip() for line in notes.splitlines()]
+          lines = [
+              line.rstrip()
+              for line in notes.splitlines()
+          ]
 
           while lines and not lines[0].strip():
               lines.pop(0)
@@ -724,6 +790,7 @@ jobs:
           TRIGGERED_BY: ${{ github.triggering_actor }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+
         run: |
           set -euo pipefail
 
@@ -758,7 +825,8 @@ jobs:
                 printf '✅ VERSION_ALREADY_PREPARED'
                 ;;
               *)
-                printf '❌ %s' "$(value_or_na "${1:-}")"
+                printf '❌ %s' \
+                  "$(value_or_na "${1:-}")"
                 ;;
             esac
           }

--- a/docs/ci/version-preparation.md
+++ b/docs/ci/version-preparation.md
@@ -101,7 +101,7 @@ The person executing the workflow explicitly supplies:
 
 ```text
 version
-changelog
+changelog_base64
 ```
 
 Example:
@@ -111,15 +111,12 @@ version:
 1.12.0+6
 ```
 
-```markdown
-### Added
+The human operator prepares the canonical Markdown release notes in a local file.
+The file is encoded as Base64 only for transport through `workflow_dispatch`.
+VERSION decodes it back to UTF-8 Markdown before validation and homologation.
 
-- Added controlled virtual amount input.
-
-### Changed
-
-- Added deterministic CI version preparation.
-```
+Base64 is a transport mechanism only.
+It does not change the release-note authority or canonical content.
 
 The workflow does not infer whether a contribution is:
 
@@ -195,7 +192,8 @@ Example:
 ```
 
 When VERSION is prepared, the workflow receives the canonical release notes
-explicitly.
+explicitly in `changelog_base64`, decodes it as UTF-8 Markdown, and then
+validates/homologates it.
 
 The human operator owns the release-note content.
 
@@ -260,10 +258,12 @@ Before preparing a version:
    ## Unreleased
    ```
 5. `Unreleased` must contain material contribution notes.
-6. The target SemVer must be greater than the current SemVer.
-7. The target build number must be greater than the current build number.
-8. The build number must respect any previously homologated publication
-   number for the target platform.
+6. `changelog_base64` must decode successfully as UTF-8.
+7. The decoded Markdown must contain at least one level-3 section (`### ...`).
+8. The target SemVer must be greater than the current SemVer.
+9. The target build number must be greater than the current build number.
+10. The build number must respect any previously homologated publication
+    number for the target platform.
 
 ---
 
@@ -295,7 +295,19 @@ X.Y.Z+N
 and provide the canonical Markdown release block in:
 
 ```text
-changelog
+changelog_base64
+```
+
+Generate:
+
+```bash
+base64 < release-notes.md | tr -d '\n'
+```
+
+then paste the output in:
+
+```text
+changelog_base64
 ```
 
 ---
@@ -320,10 +332,12 @@ Example `release-notes.md`:
 Run:
 
 ```bash
+NOTES_BASE64="$(base64 < release-notes.md | tr -d '\n')"
+
 gh workflow run prepare_version.yaml \
   --ref develop \
-  -f version='1.12.0+6' \
-  -F changelog=@release-notes.md
+  -f version='1.12.0+7' \
+  -f changelog_base64="$NOTES_BASE64"
 ```
 
 The workflow always mutates `develop`, regardless of the caller context.
@@ -447,6 +461,25 @@ VERSION does not automatically repair inconsistent repository states.
 
 ---
 
+## CHANGELOG_INPUT_INVALID
+
+The canonical release-notes input cannot be decoded or validated.
+
+This includes:
+
+* Base64 decode failure.
+* Invalid UTF-8 decoding.
+* Empty decoded content.
+* Missing minimum structure (no `### ...` level-3 section).
+
+Expected result:
+
+```text
+FAIL
+```
+
+---
+
 # Atomic materialization
 
 A successful new preparation modifies exactly:
@@ -479,7 +512,7 @@ The version commit is materialized by GitHub Actions.
 The human operator authorizes:
 
 ```text
-version + changelog
+version + changelog_base64
 ```
 
 GitHub Actions performs the repository mutation.


### PR DESCRIPTION
## Objective

Fix the VERSION workflow transport contract so canonical multiline CHANGELOG content is preserved exactly when supplied through `workflow_dispatch`.

The previous implementation accepted raw Markdown directly through a string input. During CP-2 certification, GitHub UI transport flattened the multiline content, producing a valid but incorrectly formatted release block.

This PR fixes only that transport boundary.

## Changes

### `prepare_version.yaml`

- Replaced:
  ```text
  changelog
````

with:

```text
changelog_base64
```

* VERSION now:

  1. receives the canonical release notes encoded as Base64;
  2. validates the Base64 input;
  3. decodes it as UTF-8;
  4. restores the original multiline Markdown;
  5. validates the decoded structure;
  6. continues using the same deterministic VERSION logic.

* Added fail-closed validation for:

  * empty Base64 input;
  * invalid Base64;
  * invalid UTF-8;
  * empty decoded Markdown;
  * missing level-3 release sections (`### ...`);
  * forbidden level-2 headings controlled by VERSION.

### Documentation

Updated `docs/ci/version-preparation.md` to document:

* the new `changelog_base64` input;
* Base64 as a transport mechanism only;
* preparation of canonical release notes in a local Markdown file;
* encoding instructions for macOS/Linux;
* the corresponding `CHANGELOG_INPUT_INVALID` failure cases.

## Why Base64

Base64 does not change the authority or semantic content of the release notes.

It is used exclusively to preserve the canonical multiline UTF-8 Markdown across the `workflow_dispatch` input boundary.

Conceptually:

```text
canonical release-notes.md
          │
          ▼
        Base64
          │
          ▼
 workflow_dispatch
          │
          ▼
      UTF-8 decode
          │
          ▼
canonical release-notes.md
```

The decoded content remains the human-authorized source used by VERSION.

## Preserved contracts

This fix does not change:

* target branch authority (`develop`);
* SemVer validation;
* build-number monotonicity;
* CHANGELOG version placement;
* `expectedHeadOid`;
* atomic `createCommitOnBranch`;
* GitHub Verified commit requirement;
* human authorization traceability;
* VERSION idempotency;
* postcondition verification;
* VERSION summary structure.

## Certification context

The first CP-2 run successfully demonstrated:

* SemVer monotonicity;
* build monotonicity;
* atomic mutation;
* `expectedHeadOid`;
* one VERSION commit;
* GitHub Verified signature;
* correct `pubspec.yaml` update.

It also exposed the transport defect:

```text
Expected:
### Added

- Item A
- Item B

Observed:
### Added - Item A - Item B
```

The resulting VERSION commit was reverted, restoring the baseline:

```text
version: 1.11.1+6
## Unreleased
```

This PR prepares the workflow for a clean CP-2 rerun targeting:

```text
1.12.0+7
```

## Validation plan

After merge to `develop`:

1. prepare the canonical `1.12.0` release notes as Markdown;
2. encode them to Base64;
3. execute `prepare_version.yaml` with:

   ```text
   version = 1.12.0+7
   changelog_base64 = <encoded canonical Markdown>
   ```
4. verify:

   * `VERSION_PREPARED`;
   * correct multiline CHANGELOG structure;
   * `pubspec.yaml = 1.12.0+7`;
   * one atomic VERSION commit;
   * GitHub Verified signature;
   * postconditions pass;
5. rerun the exact same input;
6. verify:

   ```text
   VERSION_ALREADY_PREPARED
   ```

   with zero repository mutations.

## Out of scope

* artifact generation;
* tags;
* APK/AAB;
* signing of application artifacts;
* Google Play publication;
* other BUILD/PUBLISH responsibilities.

```
